### PR TITLE
Fix compatibility with Cython 3.0

### DIFF
--- a/DTLSSocket/dtls.pyx
+++ b/DTLSSocket/dtls.pyx
@@ -19,7 +19,7 @@ DTLS_LOG_INFO   = tdtls.DTLS_LOG_INFO
 DTLS_LOG_DEBUG  = tdtls.DTLS_LOG_DEBUG
 
 
-cdef int _write(dtls_context_t *ctx, session_t *session, uint8 *buf, size_t len):
+cdef int _write(dtls_context_t *ctx, session_t *session, uint8 *buf, size_t len) except -1:
   """Send data to socket"""
   self = <object>(ctx.app)
   data = buf[:len]
@@ -29,7 +29,7 @@ cdef int _write(dtls_context_t *ctx, session_t *session, uint8 *buf, size_t len)
   cdef int ret = self.pycb['write']((ip, port), data)
   return ret
   
-cdef int _read(dtls_context_t *ctx, session_t *session, uint8 *buf, size_t len):
+cdef int _read(dtls_context_t *ctx, session_t *session, uint8 *buf, size_t len) except -1:
   """Send data to application"""
   self = <object>(ctx.app)
   data = buf[:len]
@@ -39,7 +39,7 @@ cdef int _read(dtls_context_t *ctx, session_t *session, uint8 *buf, size_t len):
   cdef int ret = self.pycb['read']((ip, port), data)
   return ret
   
-cdef int _event(dtls_context_t *ctx, session_t *session, dtls_alert_level_t level, unsigned short code):
+cdef int _event(dtls_context_t *ctx, session_t *session, dtls_alert_level_t level, unsigned short code) except -1:
   """The event handler is called when a message from the alert protocol is received or the state of the DTLS session changes."""
   self = <object>(ctx.app)
   if self.pycb['event'] != None:
@@ -54,7 +54,7 @@ cdef int _get_psk_info(dtls_context_t *ctx,
 		      const unsigned char *desc_data,
 		      size_t desc_len,
 		      unsigned char *result_data,
-		      size_t result_length):
+		      size_t result_length) except -1:
   """Called during handshake to get information related to the psk key exchange. 
    
    The type of information requested is indicated by @p type 

--- a/DTLSSocket/dtls.pyx
+++ b/DTLSSocket/dtls.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 cimport tdtls
 from tdtls cimport dtls_context_t, dtls_handler_t, session_t, dtls_alert_level_t, dtls_credentials_type_t
 from libc.stdint cimport uint8_t

--- a/DTLSSocket/tdtls.pxd
+++ b/DTLSSocket/tdtls.pxd
@@ -83,10 +83,14 @@ cdef extern from "tinydtls/dtls.h":
     unsigned char readbuf[1400] #DTLS_MAX_BUF
   
   ctypedef struct dtls_handler_t:
-    int (*write)(dtls_context_t *ctx, session_t *session, uint8 *buf, size_t len)
-    int (*read)(dtls_context_t *ctx, session_t *session, uint8 *buf, size_t len)
-    int (*event)(dtls_context_t *ctx, session_t *session, dtls_alert_level_t level, unsigned short code)
-    int (*get_psk_info)(dtls_context_t *ctx, const session_t *session, dtls_credentials_type_t type, const unsigned char *desc, size_t desc_len, unsigned char *result, size_t result_length)
+    int (*write)(dtls_context_t *ctx, session_t *session, uint8 *buf, size_t len) except -1
+    # Actually, the return value is ignored by tinydtls; -1 is used for errors
+    # for consistency with write and get_psk_info
+    int (*read)(dtls_context_t *ctx, session_t *session, uint8 *buf, size_t len) except -1
+    # Actually, the return value is ignored by tinydtls; -1 is used for errors
+    # for consistency with write and get_psk_info
+    int (*event)(dtls_context_t *ctx, session_t *session, dtls_alert_level_t level, unsigned short code) except -1
+    int (*get_psk_info)(dtls_context_t *ctx, const session_t *session, dtls_credentials_type_t type, const unsigned char *desc, size_t desc_len, unsigned char *result, size_t result_length) except -1
   
   void dtls_init()
   void dtls_set_handler(dtls_context_t *ctx, dtls_handler_t *h) #inline...


### PR DESCRIPTION
This is an alternative to https://github.com/kabel42/DTLSSocket/pull/9, but is largely untested, so unless it can be tested fast, please consider going with #9 for a quick fix and then reverting it and following up with this.

This
* declares that dtls.pyx still is in Python-2 style, and
* declares how exceptions are handled in the callbacks. [The cython 3 porting guide](http://docs.cython.org/en/latest/src/userguide/migrating_to_cy30.html#exception-values-and-noexcept) has a section on this. They also say that "This was a common mistake in Cython code and the main reason to change the behaviour", and indeed I vaguely remember having seen weirdness in aiocoap when writing went awry -- so my guess is that it should still be better than than before, but I don't know exactly how to best test this.