### PR TITLE
Update requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,6 @@ setup(
     url         = "https://git.fslab.de/jkonra2m/tinydtls-cython",
     py_modules  = [ "DTLSSocket.DTLSSocket"],
     cmdclass    = {"build_ext": prepare_tinydtls},
-    setup_requires = ['setuptools>=18.0','Cython<3'],
-    install_requires = ['Cython<3'],
     ext_modules = [Extension("DTLSSocket.dtls",
                 [
                  "DTLSSocket/dtls.pyx",


### PR DESCRIPTION
`setup_requires` can be removed as that is covered by `build-system` in `pyproject.toml`.
https://github.com/mclab-hbrs/DTLSSocket/blob/34e516919cfd2c35eb41076a918dff3a214ab7ec/pyproject.toml#L1-L2

As for `install_requires`, `Cython` is only used to build the binary - not to run it. So that can be removed as well.
This will prevent the accidental `Cython` install in the virtual environment by `DTLSSocket`.

--
Tested it with `pip install -v .`